### PR TITLE
Add missing url: www.pinterest.es

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -42,6 +42,7 @@
                 "https://www.pinterest.kp/*",
                 "https://www.pinterest.fr/*",
                 "https://www.pinterest.fi/*",
+                "https://www.pinterest.es/*",
                 "https://www.pinterest.de/*",
                 "https://www.pinterest.cz/*",
                 "https://www.pinterest.ch/*",


### PR DESCRIPTION
Add missing url: www.pinterest.es to the automatically site access list.